### PR TITLE
Fix incorrect method in example: use switchToCurrentChat instead of switchToChosenChat

### DIFF
--- a/docs/keyboards/inline-keyboard.md
+++ b/docs/keyboards/inline-keyboard.md
@@ -161,9 +161,9 @@ This offers a quick way for the user to open your bot in inline mode in the same
 ```ts twoslash
 import { InlineKeyboard } from "@gramio/keyboards";
 // ---cut---
-new InlineKeyboard().switchToChosenChat("Open Inline mod");
+new InlineKeyboard().switchToCurrentChat("Open Inline mod");
 // or
-new InlineKeyboard().switchToChosenChat("Open Inline mod", "InlineQuery");
+new InlineKeyboard().switchToCurrentChat("Open Inline mod", "InlineQuery");
 ```
 
 ### game

--- a/docs/ru/keyboards/inline-keyboard.md
+++ b/docs/ru/keyboards/inline-keyboard.md
@@ -161,9 +161,9 @@ new InlineKeyboard().switchToChosenChat("Выберите чат", {
 ```ts twoslash
 import { InlineKeyboard } from "@gramio/keyboards";
 // ---cut---
-new InlineKeyboard().switchToChosenChat("Открыть инлайн режим");
+new InlineKeyboard().switchToCurrentChat("Открыть инлайн режим");
 // или
-new InlineKeyboard().switchToChosenChat("Открыть инлайн режим", "InlineQuery");
+new InlineKeyboard().switchToCurrentChat("Открыть инлайн режим", "InlineQuery");
 ```
 
 ### game


### PR DESCRIPTION
Fix incorrect method name: switchToChosenChat -> switchToCurrentChat in inline keyboard example