### PR TITLE
Add --allow-env to Deno run command

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -194,7 +194,7 @@ bun ./src/index.ts
 ```
 
 ```bash [deno]
-deno run --allow-net ./src/index.ts
+deno run --allow-net --allow-env ./src/index.ts
 ```
 
 :::


### PR DESCRIPTION
Enable access to environment variables by adding --allow-env.

https://github.com/gramiojs/gramio/issues/12