### PR TITLE
fix: correct Composer import path in docs

### DIFF
--- a/docs/extend/middleware.md
+++ b/docs/extend/middleware.md
@@ -173,14 +173,14 @@ const bot = new Bot(process.env.BOT_TOKEN as string)
 ## Build-Time Conditionals: when()
 
 ::: info Composer-level API
-`when()` is available on `Composer` from `@gramio/composer`. Create your pipeline as a `Composer`, then pass it to `bot.extend()`.
+`when()` is available on `Composer` from `gramio`. Create your pipeline as a `Composer`, then pass it to `bot.extend()`.
 :::
 
 Register middleware conditionally at **startup** (not per-request) using `when()`. The middleware is either registered or not — there's no runtime overhead:
 
 ```ts
 import { Bot } from "gramio";
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 const pipeline = new Composer()
     .when(
@@ -206,7 +206,7 @@ The real power comes when you extract common middleware into a **`Composer`** an
 
 ```ts
 import { Bot } from "gramio";
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 // ── shared middleware ─────────────────────────────────────────────────
 const db = {
@@ -232,7 +232,7 @@ const bot = new Bot(process.env.BOT_TOKEN as string)
     });
 ```
 
-`Composer` from `@gramio/composer` is the building block for reusable middleware. Think of it as a named, extractable pipeline segment.
+`Composer` from `gramio` is the building block for reusable middleware. Think of it as a named, extractable pipeline segment.
 
 ### Middleware order matters
 
@@ -240,7 +240,7 @@ Middleware runs in **registration order**. A `Composer` injects its middleware a
 
 ```ts
 import { Bot } from "gramio";
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 const logger = new Composer().use(async (ctx, next) => {
     console.log("before:", ctx.updateType);
@@ -261,7 +261,7 @@ Handlers defined inline always have correct types inferred. But when you extract
 
 ```ts
 import { Bot } from "gramio";
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 const userMiddleware = new Composer().derive(() => ({
     user: { name: "Alice", premium: true as boolean },
@@ -290,7 +290,7 @@ For simple handlers, keeping them inline in the chain is the most ergonomic — 
 
 ```ts
 import { Bot } from "gramio";
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 const db = {
     getUser: (id: number) =>
@@ -314,7 +314,7 @@ const bot = new Bot(process.env.BOT_TOKEN as string)
 
 ```ts
 // middleware/user.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 export const withUser = new Composer()
     .derive(async (ctx) => ({ user: await db.getUser(ctx.from?.id ?? 0) }));
 
@@ -329,7 +329,7 @@ const bot = new Bot(TOKEN)
 
 ```ts
 import { Bot } from "gramio";
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 const FEATURES = {
     betaAnalytics: process.env.FEATURE_ANALYTICS === "true",
@@ -369,7 +369,7 @@ Name your shared Composer and mark it `.as("scoped")`. Both matter:
 
 ```ts
 // middleware/user.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 export const db = {
     getUser: (id: number) =>
@@ -394,7 +394,7 @@ export const withUser = new Composer({ name: "withUser" })
 
 ```ts
 // routers/admin.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 import { withUser } from "../middleware/user";
 
 export const adminRouter = new Composer({ name: "adminRouter" })
@@ -415,7 +415,7 @@ TypeScript infers `ctx.user` and `ctx.db` because `adminRouter` extends `withUse
 
 ```ts
 // routers/chat.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 import { db, withUser } from "../middleware/user";
 
 const withChat = new Composer({ name: "withChat" })
@@ -490,7 +490,7 @@ It only bites when two routers both call `next()` for the same update, which is 
 One DB query per update, `ctx.user` available everywhere.
 
 ::: tip `guard()` lives on Composer
-`guard()` is available on `Composer` from `@gramio/composer`, not on `Bot` directly. That's why `adminRouter` is a `Composer` — it gets the full composition API — and is then passed to `bot.extend()`.
+`guard()` is available on `Composer` from `gramio`, not on `Bot` directly. That's why `adminRouter` is a `Composer` — it gets the full composition API — and is then passed to `bot.extend()`.
 :::
 
 ## Summary

--- a/docs/guides/composer.md
+++ b/docs/guides/composer.md
@@ -50,7 +50,7 @@ const bot = new Bot(token)
 The difference: a `Composer` isn't a bot. It has no token, no API connection. It's a pipeline segment you compose into a bot with `.extend()`.
 
 ```ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 // A self-contained feature module
 const adminRouter = new Composer()
@@ -72,7 +72,7 @@ The most common use: one file per feature.
 
 ```ts
 // src/features/start.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 export const startRouter = new Composer()
     .command("start", (ctx) => ctx.send("Hello! 👋"))
@@ -81,7 +81,7 @@ export const startRouter = new Composer()
 
 ```ts
 // src/features/admin.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 const ADMIN_ID = Number(process.env.ADMIN_ID);
 
@@ -113,7 +113,7 @@ Often multiple modules need the same data — a user record, config, a database 
 
 ```ts
 // src/middleware/user.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 export const withUser = new Composer()
     .derive(async (ctx) => ({
@@ -126,7 +126,7 @@ Extend it in your feature module to get the type:
 
 ```ts
 // src/features/profile.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 import { withUser } from "../middleware/user";
 
 export const profileRouter = new Composer()
@@ -164,7 +164,8 @@ When you extract a handler to a standalone function, TypeScript needs a type ann
 
 ```ts
 // src/middleware/user.ts
-import { Composer, type ContextOf } from "@gramio/composer";
+import { Composer } from "gramio";
+import type { ContextOf } from "@gramio/composer";
 
 export const withUser = new Composer()
     .derive(() => ({
@@ -187,7 +188,7 @@ export async function handleProfile(ctx: WithUser) {
 
 ```ts
 // src/features/profile.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 import { withUser } from "../middleware/user";
 import { handleProfile } from "../handlers/profile";
 
@@ -204,7 +205,7 @@ For things that don't change per request — database clients, config, service i
 
 ```ts
 // src/middleware/deps.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 import { db } from "../db";
 import { config } from "../config";
 
@@ -215,7 +216,7 @@ export const withDeps = new Composer()
 
 ```ts
 // src/features/admin.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 import { withDeps } from "../middleware/deps";
 
 export const adminRouter = new Composer()
@@ -287,7 +288,7 @@ export const rateLimitPlugin = new Plugin("rate-limit")
     });
 
 // ✅ Composer — for everything else inside your own bot
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 const adminRouter = new Composer()
     .guard((ctx) => ctx.from?.id === ADMIN_ID)
     .command("ban", (ctx) => ctx.send("Banned!"));

--- a/docs/index.md
+++ b/docs/index.md
@@ -149,7 +149,7 @@ const bot = new Bot(process.env.BOT_TOKEN as string)
 
 ```ts [Composer]
 import { Bot } from "gramio";
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 // Shared middleware — typed context available in every module
 const withUser = new Composer()

--- a/docs/ru/extend/middleware.md
+++ b/docs/ru/extend/middleware.md
@@ -159,14 +159,14 @@ const bot = new Bot(process.env.BOT_TOKEN as string)
 ## Условная регистрация: when()
 
 ::: info API уровня Composer
-`when()` доступен на `Composer` из `@gramio/composer`. Создайте конвейер как `Composer`, затем подключите его через `bot.extend()`.
+`when()` доступен на `Composer` из `gramio`. Создайте конвейер как `Composer`, затем подключите его через `bot.extend()`.
 :::
 
 Регистрируйте middleware условно при **запуске** (не на каждом запросе) с помощью `when()`. Middleware либо регистрируется, либо нет — накладных расходов в рантайме нет:
 
 ```ts
 import { Bot } from "gramio";
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 const pipeline = new Composer()
     .when(
@@ -187,11 +187,11 @@ const bot = new Bot(process.env.BOT_TOKEN as string)
 
 ## Компоновка и переиспользование: Composer
 
-Для переиспользования middleware-групп используйте `Composer` из `@gramio/composer`:
+Для переиспользования middleware-групп используйте `Composer` из `gramio`:
 
 ```ts
 import { Bot } from "gramio";
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 // ── Переиспользуемый middleware с derive ───────────────────────────────
 const userMiddleware = new Composer()
@@ -218,7 +218,7 @@ Middleware выполняется **в порядке регистрации**. 
 
 ```ts
 import { Bot } from "gramio";
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 const logger = new Composer().use(async (ctx, next) => {
     console.log("до:", ctx.updateType);
@@ -239,7 +239,7 @@ const bot = new Bot(process.env.BOT_TOKEN as string)
 
 ```ts
 import { Bot } from "gramio";
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 const db = {
     getUser: (id: number) =>
@@ -263,7 +263,7 @@ const bot = new Bot(process.env.BOT_TOKEN as string)
 
 ```ts
 // middleware/user.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 export const withUser = new Composer()
     .derive(async (ctx) => ({ user: await db.getUser(ctx.from?.id ?? 0) }));
 
@@ -278,7 +278,7 @@ const bot = new Bot(TOKEN)
 
 ```ts
 import { Bot } from "gramio";
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 const FEATURES = {
     debugMode: process.env.NODE_ENV !== "production",
@@ -316,7 +316,7 @@ bot
 
 ```ts
 // middleware/user.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 export const db = {
     getUser: (id: number) =>
@@ -341,7 +341,7 @@ export const withUser = new Composer({ name: "withUser" })
 
 ```ts
 // routers/admin.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 import { withUser } from "../middleware/user";
 
 export const adminRouter = new Composer({ name: "adminRouter" })
@@ -362,7 +362,7 @@ TypeScript выводит `ctx.user` и `ctx.db` потому что `adminRoute
 
 ```ts
 // routers/chat.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 import { db, withUser } from "../middleware/user";
 
 const withChat = new Composer({ name: "withChat" })
@@ -437,7 +437,7 @@ TypeScript-типы корректны; рантайм — нет. Это еди
 Один DB-запрос на обновление, `ctx.user` доступен везде.
 
 ::: tip `guard()` — это уровень Composer
-`guard()` доступен на `Composer` из `@gramio/composer`, а не напрямую на `Bot`. Именно поэтому `adminRouter` — это `Composer`: он получает полный composition API, а затем передаётся в `bot.extend()`.
+`guard()` доступен на `Composer` из `gramio`, а не напрямую на `Bot`. Именно поэтому `adminRouter` — это `Composer`: он получает полный composition API, а затем передаётся в `bot.extend()`.
 :::
 
 ## Итог

--- a/docs/ru/guides/composer.md
+++ b/docs/ru/guides/composer.md
@@ -50,7 +50,7 @@ const bot = new Bot(token)
 Отличие: `Composer` — не бот. У него нет токена, нет API-соединения. Это сегмент пайплайна, который вы компонуете в бот через `.extend()`.
 
 ```ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 // Самодостаточный feature-модуль
 const adminRouter = new Composer()
@@ -72,7 +72,7 @@ const bot = new Bot(token)
 
 ```ts
 // src/features/start.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 export const startRouter = new Composer()
     .command("start", (ctx) => ctx.send("Привет! 👋"))
@@ -81,7 +81,7 @@ export const startRouter = new Composer()
 
 ```ts
 // src/features/admin.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 const ADMIN_ID = Number(process.env.ADMIN_ID);
 
@@ -113,7 +113,7 @@ const bot = new Bot(process.env.BOT_TOKEN as string)
 
 ```ts
 // src/middleware/user.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 export const withUser = new Composer()
     .derive(async (ctx) => ({
@@ -126,7 +126,7 @@ export const withUser = new Composer()
 
 ```ts
 // src/features/profile.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 import { withUser } from "../middleware/user";
 
 export const profileRouter = new Composer()
@@ -164,7 +164,8 @@ const bot = new Bot(process.env.BOT_TOKEN as string)
 
 ```ts
 // src/middleware/user.ts
-import { Composer, type ContextOf } from "@gramio/composer";
+import { Composer } from "gramio";
+import type { ContextOf } from "@gramio/composer";
 
 export const withUser = new Composer()
     .derive(() => ({
@@ -187,7 +188,7 @@ export async function handleProfile(ctx: WithUser) {
 
 ```ts
 // src/features/profile.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 import { withUser } from "../middleware/user";
 import { handleProfile } from "../handlers/profile";
 
@@ -204,7 +205,7 @@ export const profileRouter = new Composer()
 
 ```ts
 // src/middleware/deps.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 import { db } from "../db";
 import { config } from "../config";
 
@@ -215,7 +216,7 @@ export const withDeps = new Composer()
 
 ```ts
 // src/features/admin.ts
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 import { withDeps } from "../middleware/deps";
 
 export const adminRouter = new Composer()
@@ -287,7 +288,7 @@ export const rateLimitPlugin = new Plugin("rate-limit")
     });
 
 // ✅ Composer — для всего остального внутри вашего бота
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 const adminRouter = new Composer()
     .guard((ctx) => ctx.from?.id === ADMIN_ID)
     .command("ban", (ctx) => ctx.send("Заблокирован!"));

--- a/docs/ru/index.md
+++ b/docs/ru/index.md
@@ -149,7 +149,7 @@ const bot = new Bot(process.env.BOT_TOKEN as string)
 
 ```ts [Composer]
 import { Bot } from "gramio";
-import { Composer } from "@gramio/composer";
+import { Composer } from "gramio";
 
 // Общий middleware — типизированный контекст доступен в каждом модуле
 const withUser = new Composer()


### PR DESCRIPTION
Replace `import { Composer } from "@gramio/composer"` with `import { Composer } from "gramio"` across user-facing docs. The `@gramio/composer` package is an internal utility — users should import `Composer` from `gramio`.